### PR TITLE
Ci

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -52,14 +52,14 @@ jobs:
       run: sudo apt-get install doxygen 
       shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
-          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make doc
     - uses: actions/upload-artifact@v2
       with:
@@ -78,14 +78,14 @@ jobs:
       run: sudo apt-get install doxygen 
       shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
-          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make doc
     - uses: actions/upload-artifact@v2
       with:
@@ -105,14 +105,14 @@ jobs:
       run: sudo apt-get install doxygen 
       shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
-          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make doc
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -13,6 +13,8 @@ jobs:
 
   build-doc-IEC61970_16v29a:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_16v29a
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
@@ -21,25 +23,27 @@ jobs:
       run: sudo apt-get install doxygen 
       shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/
+      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a
+          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
+          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
           make doc
     - uses: actions/upload-artifact@v2
       with:
-        name: doc
-        path: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/doc/html
+        name: doc_${{env.USE_CIM_VERSION}}
+        path: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/doc/html
         retention-days: 90
 
 
 
   build-doc-IEC61970_17v07:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_17v07
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
@@ -47,26 +51,25 @@ jobs:
     - name: Install Doxygen
       run: sudo apt-get install doxygen 
       shell: bash 
-
-
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_17v07
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/
+      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_17v07 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_17v07
+          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
+          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
           make doc
     - uses: actions/upload-artifact@v2
       with:
-        name: doc
-        path: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/doc/html
-        retention-days: 90
+        name: doc_${{env.USE_CIM_VERSION}}
+        path: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/doc/html
 
   build-doc-IEC61970_16v29a_IEC61968_12v08:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_16v29a_IEC61968_12v08
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
@@ -74,27 +77,26 @@ jobs:
     - name: Install Doxygen
       run: sudo apt-get install doxygen 
       shell: bash 
-
-
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
+          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
           make doc
     - uses: actions/upload-artifact@v2
       with:
-        name: doc
-        path: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/doc/html
-        retention-days: 90
+        name: doc_${{env.USE_CIM_VERSION}}
+        path: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/doc/html
 
 
   build-doc-CGMES_2-4-15_27JAN2020:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: CGMES_2.4.15_27JAN2020
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
@@ -102,23 +104,20 @@ jobs:
     - name: Install Doxygen
       run: sudo apt-get install doxygen 
       shell: bash 
-
-
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020/
+      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020
-          cmake ../.. -DUSE_CIM_VERSION=CGMES_2.4.15_27JAN2020
+          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
+          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
           make doc
     - uses: actions/upload-artifact@v2
       with:
-        name: doc
-        path: ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020/doc/html
-        retention-days: 90
+        name: doc_${{env.USE_CIM_VERSION}}
+        path: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/doc/html
 
 
 

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -1,0 +1,124 @@
+name: build-doc
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  DOCKER_TAG_DEV: ${CI_COMMIT_REF_NAME}
+  DOCKER_IMAGE_DEV: libcimpp-dev
+
+
+jobs:
+
+  build-doc-IEC61970_16v29a:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a
+          make doc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: doc
+        path: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/doc/html
+        retention-days: 90
+
+
+
+  build-doc-IEC61970_17v07:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
+
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_17v07
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_17v07 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_17v07
+          make doc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: doc
+        path: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/doc/html
+        retention-days: 90
+
+  build-doc-IEC61970_16v29a_IEC61968_12v08:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
+
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          make doc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: doc
+        path: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/doc/html
+        retention-days: 90
+
+
+  build-doc-CGMES_2-4-15_27JAN2020:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
+
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020
+          cmake ../.. -DUSE_CIM_VERSION=CGMES_2.4.15_27JAN2020
+          make doc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: doc
+        path: ${{runner.workspace}}/libcimpp/build/CGMES_2.4.15_27JAN2020/doc/html
+        retention-days: 90
+
+
+

--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -23,14 +23,14 @@ jobs:
       run: sudo apt-get install doxygen 
       shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/$USE_CIM_VERSION 
-          cmake ../.. -DUSE_CIM_VERSION=$USE_CIM_VERSION
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make doc
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -1,0 +1,90 @@
+name: CMake
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  DOCKER_TAG_DEV: ${CI_COMMIT_REF_NAME}
+  DOCKER_IMAGE_DEV: libcimpp-dev
+
+
+jobs:
+
+  build-src-IEC61970_16v29a:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a
+          make -j8
+
+
+
+  build-src-IEC61970_17v07:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_17v07
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_17v07 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_17v07
+          make -j8
+
+  build-src-IEC61970_16v29a_IEC61968_12v08:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          make -j8
+
+
+  build-src-CGMES_2-4-15_27JAN2020:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      
+    - name: Configure CMake and compile
+      shell: bash
+      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      run: |
+          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
+          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          make -j8
+
+
+

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: build-src
 
 on: [push]
 

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -13,78 +13,93 @@ jobs:
 
   build-src-IEC61970_16v29a:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_16v29a
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
       run: git submodule update --init --recursive
-
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make -j8
 
 
 
   build-src-IEC61970_17v07:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_17v07
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
       run: git submodule update --init --recursive
-
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_17v07
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_17v07/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_17v07 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_17v07
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make -j8
 
   build-src-IEC61970_16v29a_IEC61968_12v08:
     runs-on: ubuntu-latest
+    env:
+      USE_CIM_VERSION: IEC61970_16v29a_IEC61968_12v08
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
       run: git submodule update --init --recursive
-
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make -j8
 
 
   build-src-CGMES_2-4-15_27JAN2020:
     runs-on: ubuntu-latest
+
+    env:
+      USE_CIM_VERSION: CGMES_2.4.15_27JAN2020
     steps:
     - uses: actions/checkout@v2    
     - name: Checkout submodules
       run: git submodule update --init --recursive
-
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen 
+      shell: bash 
     - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08
+      run: cmake -E make_directory ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}
       
     - name: Configure CMake and compile
       shell: bash
-      working-directory: ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08/
+      working-directory: ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}}/
       run: |
-          cd ${{runner.workspace}}/libcimpp/build/IEC61970_16v29a_IEC61968_12v08 
-          cmake ../.. -DUSE_CIM_VERSION=IEC61970_16v29a_IEC61968_12v08
+          cd ${{runner.workspace}}/libcimpp/build/${{env.USE_CIM_VERSION}} 
+          cmake ../.. -DUSE_CIM_VERSION=${{env.USE_CIM_VERSION}}
           make -j8
-
-
 


### PR DESCRIPTION
Implemented equivalent ci stages to the .gitlab-ci.yml.  
The build-doc.yml builds the doc and uploads the artifact.  
The build-src.yml builds the code.  
Due to the fact that github does not support anchors up to now we can not use the nice templating scheme from gitlab. 
I experimented with the new github [composite run steps action](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action) but up to now it seems that they are also not capable of realizing our ci stages in an abstract way (e.g. it is not possible to use other actions from inside them which is needed for example the upload artifact action).  
Thus the only possibility was to create one large yml for build-doc and build-src where most of the code repeats.
