### PR TITLE
Prevent cutting of string values

### DIFF
--- a/CGMES_2.4.13_18DEC2013/BasicIntervalSchedule.cpp
+++ b/CGMES_2.4.13_18DEC2013/BasicIntervalSchedule.cpp
@@ -20,7 +20,7 @@ bool assign_BasicIntervalSchedule_startTime(std::stringstream &buffer, BaseClass
 {
 	if (BasicIntervalSchedule* element = dynamic_cast<BasicIntervalSchedule*>(BaseClass_ptr1))
 	{
-		buffer >> element->startTime;
+		element->startTime = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/ConnectivityNode.cpp
+++ b/CGMES_2.4.13_18DEC2013/ConnectivityNode.cpp
@@ -43,7 +43,7 @@ bool assign_ConnectivityNode_fromEndIsoCode(std::stringstream &buffer, BaseClass
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndIsoCode;
+		element->fromEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -56,7 +56,7 @@ bool assign_ConnectivityNode_fromEndName(std::stringstream &buffer, BaseClass* B
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndName;
+		element->fromEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -69,7 +69,7 @@ bool assign_ConnectivityNode_fromEndNameTso(std::stringstream &buffer, BaseClass
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndNameTso;
+		element->fromEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -82,7 +82,7 @@ bool assign_ConnectivityNode_toEndIsoCode(std::stringstream &buffer, BaseClass* 
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndIsoCode;
+		element->toEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -95,7 +95,7 @@ bool assign_ConnectivityNode_toEndName(std::stringstream &buffer, BaseClass* Bas
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndName;
+		element->toEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -108,7 +108,7 @@ bool assign_ConnectivityNode_toEndNameTso(std::stringstream &buffer, BaseClass* 
 {
 	if (ConnectivityNode* element = dynamic_cast<ConnectivityNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndNameTso;
+		element->toEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/Control.cpp
+++ b/CGMES_2.4.13_18DEC2013/Control.cpp
@@ -24,7 +24,7 @@ bool assign_Control_controlType(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (Control* element = dynamic_cast<Control*>(BaseClass_ptr1))
 	{
-		buffer >> element->controlType;
+		element->controlType = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -50,7 +50,7 @@ bool assign_Control_timeStamp(std::stringstream &buffer, BaseClass* BaseClass_pt
 {
 	if (Control* element = dynamic_cast<Control*>(BaseClass_ptr1))
 	{
-		buffer >> element->timeStamp;
+		element->timeStamp = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/CoordinateSystem.cpp
+++ b/CGMES_2.4.13_18DEC2013/CoordinateSystem.cpp
@@ -20,7 +20,7 @@ bool assign_CoordinateSystem_crsUrn(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (CoordinateSystem* element = dynamic_cast<CoordinateSystem*>(BaseClass_ptr1))
 	{
-		buffer >> element->crsUrn;
+		element->crsUrn = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/DiagramLayoutVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/DiagramLayoutVersion.cpp
@@ -27,7 +27,7 @@ bool assign_DiagramLayoutVersion_baseUML(std::stringstream &buffer, BaseClass* B
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_DiagramLayoutVersion_baseURI(std::stringstream &buffer, BaseClass* B
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_DiagramLayoutVersion_date(std::stringstream &buffer, BaseClass* Base
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_DiagramLayoutVersion_differenceModelURI(std::stringstream &buffer, B
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_DiagramLayoutVersion_entsoeUML(std::stringstream &buffer, BaseClass*
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_DiagramLayoutVersion_entsoeURI(std::stringstream &buffer, BaseClass*
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_DiagramLayoutVersion_modelDescriptionURI(std::stringstream &buffer, 
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_DiagramLayoutVersion_namespaceRDF(std::stringstream &buffer, BaseCla
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_DiagramLayoutVersion_namespaceUML(std::stringstream &buffer, BaseCla
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_DiagramLayoutVersion_shortName(std::stringstream &buffer, BaseClass*
 {
 	if (DiagramLayoutVersion* element = dynamic_cast<DiagramLayoutVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/DynamicsVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/DynamicsVersion.cpp
@@ -27,7 +27,7 @@ bool assign_DynamicsVersion_baseUML(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_DynamicsVersion_baseURI(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_DynamicsVersion_date(std::stringstream &buffer, BaseClass* BaseClass
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_DynamicsVersion_differenceModelURI(std::stringstream &buffer, BaseCl
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_DynamicsVersion_entsoeUML(std::stringstream &buffer, BaseClass* Base
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_DynamicsVersion_entsoeURI(std::stringstream &buffer, BaseClass* Base
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_DynamicsVersion_modelDescriptionURI(std::stringstream &buffer, BaseC
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_DynamicsVersion_namespaceRDF(std::stringstream &buffer, BaseClass* B
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_DynamicsVersion_namespaceUML(std::stringstream &buffer, BaseClass* B
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_DynamicsVersion_shortName(std::stringstream &buffer, BaseClass* Base
 {
 	if (DynamicsVersion* element = dynamic_cast<DynamicsVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/EquipmentBoundaryVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/EquipmentBoundaryVersion.cpp
@@ -28,7 +28,7 @@ bool assign_EquipmentBoundaryVersion_baseUML(std::stringstream &buffer, BaseClas
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -41,7 +41,7 @@ bool assign_EquipmentBoundaryVersion_baseURI(std::stringstream &buffer, BaseClas
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -54,7 +54,7 @@ bool assign_EquipmentBoundaryVersion_date(std::stringstream &buffer, BaseClass* 
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -67,7 +67,7 @@ bool assign_EquipmentBoundaryVersion_differenceModelURI(std::stringstream &buffe
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -80,7 +80,7 @@ bool assign_EquipmentBoundaryVersion_entsoeUML(std::stringstream &buffer, BaseCl
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -93,7 +93,7 @@ bool assign_EquipmentBoundaryVersion_entsoeURIcore(std::stringstream &buffer, Ba
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURIcore;
+		element->entsoeURIcore = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -106,7 +106,7 @@ bool assign_EquipmentBoundaryVersion_entsoeURIoperation(std::stringstream &buffe
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURIoperation;
+		element->entsoeURIoperation = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -119,7 +119,7 @@ bool assign_EquipmentBoundaryVersion_modelDescriptionURI(std::stringstream &buff
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -132,7 +132,7 @@ bool assign_EquipmentBoundaryVersion_namespaceRDF(std::stringstream &buffer, Bas
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -145,7 +145,7 @@ bool assign_EquipmentBoundaryVersion_namespaceUML(std::stringstream &buffer, Bas
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -158,7 +158,7 @@ bool assign_EquipmentBoundaryVersion_shortName(std::stringstream &buffer, BaseCl
 {
 	if (EquipmentBoundaryVersion* element = dynamic_cast<EquipmentBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/EquipmentVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/EquipmentVersion.cpp
@@ -31,7 +31,7 @@ bool assign_EquipmentVersion_baseUML(std::stringstream &buffer, BaseClass* BaseC
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -44,7 +44,7 @@ bool assign_EquipmentVersion_baseURIcore(std::stringstream &buffer, BaseClass* B
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURIcore;
+		element->baseURIcore = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -57,7 +57,7 @@ bool assign_EquipmentVersion_baseURIoperation(std::stringstream &buffer, BaseCla
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURIoperation;
+		element->baseURIoperation = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -70,7 +70,7 @@ bool assign_EquipmentVersion_baseURIshortCircuit(std::stringstream &buffer, Base
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURIshortCircuit;
+		element->baseURIshortCircuit = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -83,7 +83,7 @@ bool assign_EquipmentVersion_date(std::stringstream &buffer, BaseClass* BaseClas
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -96,7 +96,7 @@ bool assign_EquipmentVersion_differenceModelURI(std::stringstream &buffer, BaseC
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -109,7 +109,7 @@ bool assign_EquipmentVersion_entsoeUML(std::stringstream &buffer, BaseClass* Bas
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -122,7 +122,7 @@ bool assign_EquipmentVersion_entsoeURIcore(std::stringstream &buffer, BaseClass*
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURIcore;
+		element->entsoeURIcore = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -135,7 +135,7 @@ bool assign_EquipmentVersion_entsoeURIoperation(std::stringstream &buffer, BaseC
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURIoperation;
+		element->entsoeURIoperation = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -148,7 +148,7 @@ bool assign_EquipmentVersion_entsoeURIshortCircuit(std::stringstream &buffer, Ba
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURIshortCircuit;
+		element->entsoeURIshortCircuit = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -161,7 +161,7 @@ bool assign_EquipmentVersion_modelDescriptionURI(std::stringstream &buffer, Base
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -174,7 +174,7 @@ bool assign_EquipmentVersion_namespaceRDF(std::stringstream &buffer, BaseClass* 
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -187,7 +187,7 @@ bool assign_EquipmentVersion_namespaceUML(std::stringstream &buffer, BaseClass* 
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -200,7 +200,7 @@ bool assign_EquipmentVersion_shortName(std::stringstream &buffer, BaseClass* Bas
 {
 	if (EquipmentVersion* element = dynamic_cast<EquipmentVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/GeographicalLocationVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/GeographicalLocationVersion.cpp
@@ -27,7 +27,7 @@ bool assign_GeographicalLocationVersion_baseUML(std::stringstream &buffer, BaseC
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_GeographicalLocationVersion_baseURI(std::stringstream &buffer, BaseC
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_GeographicalLocationVersion_date(std::stringstream &buffer, BaseClas
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_GeographicalLocationVersion_differenceModelURI(std::stringstream &bu
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_GeographicalLocationVersion_entsoeUML(std::stringstream &buffer, Bas
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_GeographicalLocationVersion_entsoeURI(std::stringstream &buffer, Bas
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_GeographicalLocationVersion_modelDescriptionURI(std::stringstream &b
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_GeographicalLocationVersion_namespaceRDF(std::stringstream &buffer, 
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_GeographicalLocationVersion_namespaceUML(std::stringstream &buffer, 
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_GeographicalLocationVersion_shortName(std::stringstream &buffer, Bas
 {
 	if (GeographicalLocationVersion* element = dynamic_cast<GeographicalLocationVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/IdentifiedObject.cpp
+++ b/CGMES_2.4.13_18DEC2013/IdentifiedObject.cpp
@@ -24,7 +24,7 @@ bool assign_IdentifiedObject_description(std::stringstream &buffer, BaseClass* B
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->description;
+		element->description = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -37,7 +37,7 @@ bool assign_IdentifiedObject_energyIdentCodeEic(std::stringstream &buffer, BaseC
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->energyIdentCodeEic;
+		element->energyIdentCodeEic = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -50,7 +50,7 @@ bool assign_IdentifiedObject_mRID(std::stringstream &buffer, BaseClass* BaseClas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->mRID;
+		element->mRID = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -63,7 +63,7 @@ bool assign_IdentifiedObject_name(std::stringstream &buffer, BaseClass* BaseClas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->name;
+		element->name = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -76,7 +76,7 @@ bool assign_IdentifiedObject_shortName(std::stringstream &buffer, BaseClass* Bas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/Measurement.cpp
+++ b/CGMES_2.4.13_18DEC2013/Measurement.cpp
@@ -25,7 +25,7 @@ bool assign_Measurement_measurementType(std::stringstream &buffer, BaseClass* Ba
 {
 	if (Measurement* element = dynamic_cast<Measurement*>(BaseClass_ptr1))
 	{
-		buffer >> element->measurementType;
+		element->measurementType = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/MeasurementValue.cpp
+++ b/CGMES_2.4.13_18DEC2013/MeasurementValue.cpp
@@ -36,7 +36,7 @@ bool assign_MeasurementValue_timeStamp(std::stringstream &buffer, BaseClass* Bas
 {
 	if (MeasurementValue* element = dynamic_cast<MeasurementValue*>(BaseClass_ptr1))
 	{
-		buffer >> element->timeStamp;
+		element->timeStamp = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/PositionPoint.cpp
+++ b/CGMES_2.4.13_18DEC2013/PositionPoint.cpp
@@ -36,7 +36,7 @@ bool assign_PositionPoint_xPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->xPosition;
+		element->xPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -49,7 +49,7 @@ bool assign_PositionPoint_yPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->yPosition;
+		element->yPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -62,7 +62,7 @@ bool assign_PositionPoint_zPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->zPosition;
+		element->zPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/RegularIntervalSchedule.cpp
+++ b/CGMES_2.4.13_18DEC2013/RegularIntervalSchedule.cpp
@@ -21,7 +21,7 @@ bool assign_RegularIntervalSchedule_endTime(std::stringstream &buffer, BaseClass
 {
 	if (RegularIntervalSchedule* element = dynamic_cast<RegularIntervalSchedule*>(BaseClass_ptr1))
 	{
-		buffer >> element->endTime;
+		element->endTime = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/Season.cpp
+++ b/CGMES_2.4.13_18DEC2013/Season.cpp
@@ -21,7 +21,7 @@ bool assign_Season_endDate(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
 {
 	if (Season* element = dynamic_cast<Season*>(BaseClass_ptr1))
 	{
-		buffer >> element->endDate;
+		element->endDate = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -34,7 +34,7 @@ bool assign_Season_startDate(std::stringstream &buffer, BaseClass* BaseClass_ptr
 {
 	if (Season* element = dynamic_cast<Season*>(BaseClass_ptr1))
 	{
-		buffer >> element->startDate;
+		element->startDate = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/ShuntCompensator.cpp
+++ b/CGMES_2.4.13_18DEC2013/ShuntCompensator.cpp
@@ -119,7 +119,7 @@ bool assign_ShuntCompensator_switchOnDate(std::stringstream &buffer, BaseClass* 
 {
 	if (ShuntCompensator* element = dynamic_cast<ShuntCompensator*>(BaseClass_ptr1))
 	{
-		buffer >> element->switchOnDate;
+		element->switchOnDate = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/StateVariablesVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/StateVariablesVersion.cpp
@@ -27,7 +27,7 @@ bool assign_StateVariablesVersion_baseUML(std::stringstream &buffer, BaseClass* 
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_StateVariablesVersion_baseURI(std::stringstream &buffer, BaseClass* 
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_StateVariablesVersion_date(std::stringstream &buffer, BaseClass* Bas
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_StateVariablesVersion_differenceModelURI(std::stringstream &buffer, 
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_StateVariablesVersion_entsoeUML(std::stringstream &buffer, BaseClass
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_StateVariablesVersion_entsoeURI(std::stringstream &buffer, BaseClass
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_StateVariablesVersion_modelDescriptionURI(std::stringstream &buffer,
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_StateVariablesVersion_namespaceRDF(std::stringstream &buffer, BaseCl
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_StateVariablesVersion_namespaceUML(std::stringstream &buffer, BaseCl
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_StateVariablesVersion_shortName(std::stringstream &buffer, BaseClass
 {
 	if (StateVariablesVersion* element = dynamic_cast<StateVariablesVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/SteadyStateHypothesisVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/SteadyStateHypothesisVersion.cpp
@@ -27,7 +27,7 @@ bool assign_SteadyStateHypothesisVersion_baseUML(std::stringstream &buffer, Base
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_SteadyStateHypothesisVersion_baseURI(std::stringstream &buffer, Base
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_SteadyStateHypothesisVersion_date(std::stringstream &buffer, BaseCla
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_SteadyStateHypothesisVersion_differenceModelURI(std::stringstream &b
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_SteadyStateHypothesisVersion_entsoeUML(std::stringstream &buffer, Ba
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_SteadyStateHypothesisVersion_entsoeURI(std::stringstream &buffer, Ba
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_SteadyStateHypothesisVersion_modelDescriptionURI(std::stringstream &
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_SteadyStateHypothesisVersion_namespaceRDF(std::stringstream &buffer,
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_SteadyStateHypothesisVersion_namespaceUML(std::stringstream &buffer,
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_SteadyStateHypothesisVersion_shortName(std::stringstream &buffer, Ba
 {
 	if (SteadyStateHypothesisVersion* element = dynamic_cast<SteadyStateHypothesisVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/StringMeasurementValue.cpp
+++ b/CGMES_2.4.13_18DEC2013/StringMeasurementValue.cpp
@@ -20,7 +20,7 @@ bool assign_StringMeasurementValue_value(std::stringstream &buffer, BaseClass* B
 {
 	if (StringMeasurementValue* element = dynamic_cast<StringMeasurementValue*>(BaseClass_ptr1))
 	{
-		buffer >> element->value;
+		element->value = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/TextDiagramObject.cpp
+++ b/CGMES_2.4.13_18DEC2013/TextDiagramObject.cpp
@@ -18,7 +18,7 @@ bool assign_TextDiagramObject_text(std::stringstream &buffer, BaseClass* BaseCla
 {
 	if (TextDiagramObject* element = dynamic_cast<TextDiagramObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->text;
+		element->text = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/TopologicalNode.cpp
+++ b/CGMES_2.4.13_18DEC2013/TopologicalNode.cpp
@@ -55,7 +55,7 @@ bool assign_TopologicalNode_fromEndIsoCode(std::stringstream &buffer, BaseClass*
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndIsoCode;
+		element->fromEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -68,7 +68,7 @@ bool assign_TopologicalNode_fromEndName(std::stringstream &buffer, BaseClass* Ba
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndName;
+		element->fromEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -81,7 +81,7 @@ bool assign_TopologicalNode_fromEndNameTso(std::stringstream &buffer, BaseClass*
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndNameTso;
+		element->fromEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -94,7 +94,7 @@ bool assign_TopologicalNode_toEndIsoCode(std::stringstream &buffer, BaseClass* B
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndIsoCode;
+		element->toEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -107,7 +107,7 @@ bool assign_TopologicalNode_toEndName(std::stringstream &buffer, BaseClass* Base
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndName;
+		element->toEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -120,7 +120,7 @@ bool assign_TopologicalNode_toEndNameTso(std::stringstream &buffer, BaseClass* B
 {
 	if (TopologicalNode* element = dynamic_cast<TopologicalNode*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndNameTso;
+		element->toEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/TopologyBoundaryVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/TopologyBoundaryVersion.cpp
@@ -27,7 +27,7 @@ bool assign_TopologyBoundaryVersion_baseUML(std::stringstream &buffer, BaseClass
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_TopologyBoundaryVersion_baseURI(std::stringstream &buffer, BaseClass
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_TopologyBoundaryVersion_date(std::stringstream &buffer, BaseClass* B
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_TopologyBoundaryVersion_differenceModelURI(std::stringstream &buffer
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_TopologyBoundaryVersion_entsoeUML(std::stringstream &buffer, BaseCla
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_TopologyBoundaryVersion_entsoeURI(std::stringstream &buffer, BaseCla
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_TopologyBoundaryVersion_modelDescriptionURI(std::stringstream &buffe
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_TopologyBoundaryVersion_namespaceRDF(std::stringstream &buffer, Base
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_TopologyBoundaryVersion_namespaceUML(std::stringstream &buffer, Base
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_TopologyBoundaryVersion_shortName(std::stringstream &buffer, BaseCla
 {
 	if (TopologyBoundaryVersion* element = dynamic_cast<TopologyBoundaryVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_2.4.13_18DEC2013/TopologyVersion.cpp
+++ b/CGMES_2.4.13_18DEC2013/TopologyVersion.cpp
@@ -27,7 +27,7 @@ bool assign_TopologyVersion_baseUML(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseUML;
+		element->baseUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_TopologyVersion_baseURI(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->baseURI;
+		element->baseURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_TopologyVersion_date(std::stringstream &buffer, BaseClass* BaseClass
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->date;
+		element->date = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -66,7 +66,7 @@ bool assign_TopologyVersion_differenceModelURI(std::stringstream &buffer, BaseCl
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->differenceModelURI;
+		element->differenceModelURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -79,7 +79,7 @@ bool assign_TopologyVersion_entsoeUML(std::stringstream &buffer, BaseClass* Base
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeUML;
+		element->entsoeUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_TopologyVersion_entsoeURI(std::stringstream &buffer, BaseClass* Base
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->entsoeURI;
+		element->entsoeURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_TopologyVersion_modelDescriptionURI(std::stringstream &buffer, BaseC
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->modelDescriptionURI;
+		element->modelDescriptionURI = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_TopologyVersion_namespaceRDF(std::stringstream &buffer, BaseClass* B
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceRDF;
+		element->namespaceRDF = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -131,7 +131,7 @@ bool assign_TopologyVersion_namespaceUML(std::stringstream &buffer, BaseClass* B
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->namespaceUML;
+		element->namespaceUML = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -144,7 +144,7 @@ bool assign_TopologyVersion_shortName(std::stringstream &buffer, BaseClass* Base
 {
 	if (TopologyVersion* element = dynamic_cast<TopologyVersion*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/BasicIntervalSchedule.cpp
+++ b/CGMES_3.0.0/BasicIntervalSchedule.cpp
@@ -20,7 +20,7 @@ bool assign_BasicIntervalSchedule_startTime(std::stringstream &buffer, BaseClass
 {
 	if (BasicIntervalSchedule* element = dynamic_cast<BasicIntervalSchedule*>(BaseClass_ptr1))
 	{
-		buffer >> element->startTime;
+		element->startTime = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/BoundaryPoint.cpp
+++ b/CGMES_3.0.0/BoundaryPoint.cpp
@@ -27,7 +27,7 @@ bool assign_BoundaryPoint_fromEndIsoCode(std::stringstream &buffer, BaseClass* B
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndIsoCode;
+		element->fromEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -40,7 +40,7 @@ bool assign_BoundaryPoint_fromEndName(std::stringstream &buffer, BaseClass* Base
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndName;
+		element->fromEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -53,7 +53,7 @@ bool assign_BoundaryPoint_fromEndNameTso(std::stringstream &buffer, BaseClass* B
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->fromEndNameTso;
+		element->fromEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -92,7 +92,7 @@ bool assign_BoundaryPoint_toEndIsoCode(std::stringstream &buffer, BaseClass* Bas
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndIsoCode;
+		element->toEndIsoCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -105,7 +105,7 @@ bool assign_BoundaryPoint_toEndName(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndName;
+		element->toEndName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -118,7 +118,7 @@ bool assign_BoundaryPoint_toEndNameTso(std::stringstream &buffer, BaseClass* Bas
 {
 	if (BoundaryPoint* element = dynamic_cast<BoundaryPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->toEndNameTso;
+		element->toEndNameTso = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/Control.cpp
+++ b/CGMES_3.0.0/Control.cpp
@@ -24,7 +24,7 @@ bool assign_Control_controlType(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (Control* element = dynamic_cast<Control*>(BaseClass_ptr1))
 	{
-		buffer >> element->controlType;
+		element->controlType = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -50,7 +50,7 @@ bool assign_Control_timeStamp(std::stringstream &buffer, BaseClass* BaseClass_pt
 {
 	if (Control* element = dynamic_cast<Control*>(BaseClass_ptr1))
 	{
-		buffer >> element->timeStamp;
+		element->timeStamp = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/CoordinateSystem.cpp
+++ b/CGMES_3.0.0/CoordinateSystem.cpp
@@ -20,7 +20,7 @@ bool assign_CoordinateSystem_crsUrn(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (CoordinateSystem* element = dynamic_cast<CoordinateSystem*>(BaseClass_ptr1))
 	{
-		buffer >> element->crsUrn;
+		element->crsUrn = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/IdentifiedObject.cpp
+++ b/CGMES_3.0.0/IdentifiedObject.cpp
@@ -24,7 +24,7 @@ bool assign_IdentifiedObject_description(std::stringstream &buffer, BaseClass* B
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->description;
+		element->description = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -37,7 +37,7 @@ bool assign_IdentifiedObject_energyIdentCodeEic(std::stringstream &buffer, BaseC
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->energyIdentCodeEic;
+		element->energyIdentCodeEic = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -50,7 +50,7 @@ bool assign_IdentifiedObject_mRID(std::stringstream &buffer, BaseClass* BaseClas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->mRID;
+		element->mRID = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -63,7 +63,7 @@ bool assign_IdentifiedObject_name(std::stringstream &buffer, BaseClass* BaseClas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->name;
+		element->name = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -76,7 +76,7 @@ bool assign_IdentifiedObject_shortName(std::stringstream &buffer, BaseClass* Bas
 {
 	if (IdentifiedObject* element = dynamic_cast<IdentifiedObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->shortName;
+		element->shortName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/Measurement.cpp
+++ b/CGMES_3.0.0/Measurement.cpp
@@ -25,7 +25,7 @@ bool assign_Measurement_measurementType(std::stringstream &buffer, BaseClass* Ba
 {
 	if (Measurement* element = dynamic_cast<Measurement*>(BaseClass_ptr1))
 	{
-		buffer >> element->measurementType;
+		element->measurementType = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/MeasurementValue.cpp
+++ b/CGMES_3.0.0/MeasurementValue.cpp
@@ -36,7 +36,7 @@ bool assign_MeasurementValue_timeStamp(std::stringstream &buffer, BaseClass* Bas
 {
 	if (MeasurementValue* element = dynamic_cast<MeasurementValue*>(BaseClass_ptr1))
 	{
-		buffer >> element->timeStamp;
+		element->timeStamp = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/PositionPoint.cpp
+++ b/CGMES_3.0.0/PositionPoint.cpp
@@ -36,7 +36,7 @@ bool assign_PositionPoint_xPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->xPosition;
+		element->xPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -49,7 +49,7 @@ bool assign_PositionPoint_yPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->yPosition;
+		element->yPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -62,7 +62,7 @@ bool assign_PositionPoint_zPosition(std::stringstream &buffer, BaseClass* BaseCl
 {
 	if (PositionPoint* element = dynamic_cast<PositionPoint*>(BaseClass_ptr1))
 	{
-		buffer >> element->zPosition;
+		element->zPosition = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/RegularIntervalSchedule.cpp
+++ b/CGMES_3.0.0/RegularIntervalSchedule.cpp
@@ -21,7 +21,7 @@ bool assign_RegularIntervalSchedule_endTime(std::stringstream &buffer, BaseClass
 {
 	if (RegularIntervalSchedule* element = dynamic_cast<RegularIntervalSchedule*>(BaseClass_ptr1))
 	{
-		buffer >> element->endTime;
+		element->endTime = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/Season.cpp
+++ b/CGMES_3.0.0/Season.cpp
@@ -21,7 +21,7 @@ bool assign_Season_endDate(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
 {
 	if (Season* element = dynamic_cast<Season*>(BaseClass_ptr1))
 	{
-		buffer >> element->endDate;
+		element->endDate = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -34,7 +34,7 @@ bool assign_Season_startDate(std::stringstream &buffer, BaseClass* BaseClass_ptr
 {
 	if (Season* element = dynamic_cast<Season*>(BaseClass_ptr1))
 	{
-		buffer >> element->startDate;
+		element->startDate = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/Status.cpp
+++ b/CGMES_3.0.0/Status.cpp
@@ -21,7 +21,7 @@ bool assign_Status_dateTime(std::stringstream &buffer, BaseClass* BaseClass_ptr1
 {
 	if (Status* element = dynamic_cast<Status*>(BaseClass_ptr1))
 	{
-		buffer >> element->dateTime;
+		element->dateTime = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -34,7 +34,7 @@ bool assign_Status_reason(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
 {
 	if (Status* element = dynamic_cast<Status*>(BaseClass_ptr1))
 	{
-		buffer >> element->reason;
+		element->reason = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -47,7 +47,7 @@ bool assign_Status_remark(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
 {
 	if (Status* element = dynamic_cast<Status*>(BaseClass_ptr1))
 	{
-		buffer >> element->remark;
+		element->remark = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -60,7 +60,7 @@ bool assign_Status_value(std::stringstream &buffer, BaseClass* BaseClass_ptr1)
 {
 	if (Status* element = dynamic_cast<Status*>(BaseClass_ptr1))
 	{
-		buffer >> element->value;
+		element->value = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/StreetAddress.cpp
+++ b/CGMES_3.0.0/StreetAddress.cpp
@@ -23,7 +23,7 @@ bool assign_StreetAddress_language(std::stringstream &buffer, BaseClass* BaseCla
 {
 	if (StreetAddress* element = dynamic_cast<StreetAddress*>(BaseClass_ptr1))
 	{
-		buffer >> element->language;
+		element->language = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -36,7 +36,7 @@ bool assign_StreetAddress_poBox(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (StreetAddress* element = dynamic_cast<StreetAddress*>(BaseClass_ptr1))
 	{
-		buffer >> element->poBox;
+		element->poBox = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -49,7 +49,7 @@ bool assign_StreetAddress_postalCode(std::stringstream &buffer, BaseClass* BaseC
 {
 	if (StreetAddress* element = dynamic_cast<StreetAddress*>(BaseClass_ptr1))
 	{
-		buffer >> element->postalCode;
+		element->postalCode = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/StreetDetail.cpp
+++ b/CGMES_3.0.0/StreetDetail.cpp
@@ -30,7 +30,7 @@ bool assign_StreetDetail_addressGeneral(std::stringstream &buffer, BaseClass* Ba
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->addressGeneral;
+		element->addressGeneral = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -43,7 +43,7 @@ bool assign_StreetDetail_addressGeneral2(std::stringstream &buffer, BaseClass* B
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->addressGeneral2;
+		element->addressGeneral2 = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -56,7 +56,7 @@ bool assign_StreetDetail_addressGeneral3(std::stringstream &buffer, BaseClass* B
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->addressGeneral3;
+		element->addressGeneral3 = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -69,7 +69,7 @@ bool assign_StreetDetail_buildingName(std::stringstream &buffer, BaseClass* Base
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->buildingName;
+		element->buildingName = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -82,7 +82,7 @@ bool assign_StreetDetail_code(std::stringstream &buffer, BaseClass* BaseClass_pt
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->code;
+		element->code = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -95,7 +95,7 @@ bool assign_StreetDetail_floorIdentification(std::stringstream &buffer, BaseClas
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->floorIdentification;
+		element->floorIdentification = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -108,7 +108,7 @@ bool assign_StreetDetail_name(std::stringstream &buffer, BaseClass* BaseClass_pt
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->name;
+		element->name = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -121,7 +121,7 @@ bool assign_StreetDetail_number(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->number;
+		element->number = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -134,7 +134,7 @@ bool assign_StreetDetail_prefix(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->prefix;
+		element->prefix = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -147,7 +147,7 @@ bool assign_StreetDetail_suffix(std::stringstream &buffer, BaseClass* BaseClass_
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->suffix;
+		element->suffix = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -160,7 +160,7 @@ bool assign_StreetDetail_suiteNumber(std::stringstream &buffer, BaseClass* BaseC
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->suiteNumber;
+		element->suiteNumber = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -173,7 +173,7 @@ bool assign_StreetDetail_type(std::stringstream &buffer, BaseClass* BaseClass_pt
 {
 	if (StreetDetail* element = dynamic_cast<StreetDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->type;
+		element->type = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/TextDiagramObject.cpp
+++ b/CGMES_3.0.0/TextDiagramObject.cpp
@@ -18,7 +18,7 @@ bool assign_TextDiagramObject_text(std::stringstream &buffer, BaseClass* BaseCla
 {
 	if (TextDiagramObject* element = dynamic_cast<TextDiagramObject*>(BaseClass_ptr1))
 	{
-		buffer >> element->text;
+		element->text = buffer.str();
 		if (buffer.fail())
 			return false;
 		else

--- a/CGMES_3.0.0/TownDetail.cpp
+++ b/CGMES_3.0.0/TownDetail.cpp
@@ -22,7 +22,7 @@ bool assign_TownDetail_code(std::stringstream &buffer, BaseClass* BaseClass_ptr1
 {
 	if (TownDetail* element = dynamic_cast<TownDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->code;
+		element->code = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -35,7 +35,7 @@ bool assign_TownDetail_country(std::stringstream &buffer, BaseClass* BaseClass_p
 {
 	if (TownDetail* element = dynamic_cast<TownDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->country;
+		element->country = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -48,7 +48,7 @@ bool assign_TownDetail_name(std::stringstream &buffer, BaseClass* BaseClass_ptr1
 {
 	if (TownDetail* element = dynamic_cast<TownDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->name;
+		element->name = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -61,7 +61,7 @@ bool assign_TownDetail_section(std::stringstream &buffer, BaseClass* BaseClass_p
 {
 	if (TownDetail* element = dynamic_cast<TownDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->section;
+		element->section = buffer.str();
 		if (buffer.fail())
 			return false;
 		else
@@ -74,7 +74,7 @@ bool assign_TownDetail_stateOrProvince(std::stringstream &buffer, BaseClass* Bas
 {
 	if (TownDetail* element = dynamic_cast<TownDetail*>(BaseClass_ptr1))
 	{
-		buffer >> element->stateOrProvince;
+		element->stateOrProvince = buffer.str();
 		if (buffer.fail())
 			return false;
 		else


### PR DESCRIPTION
 Prevent cutting of string values at first space in assign methods (update generated sources from https://github.com/tom-hg57/cimgen/tree/fix-generation-of-string-classes-for-cpp).

This PR applies the fix to CGMES 2.4.13 and 3.